### PR TITLE
Implementation for #27 (allow shorter animations)

### DIFF
--- a/Configuration/Const.cs
+++ b/Configuration/Const.cs
@@ -31,7 +31,7 @@ namespace VirtualSpace.Config
         public const int    WindowCheckInterval    = 200;
         public const int    WindowCloseTimeout     = 60 * 1000;
         public const int    RiseViewInterval       = 500;
-        public const int    SwitchDesktopInterval  = 500;
+        public const int    SwitchDesktopInterval  = 100;
         public const int    DefaultDpi             = 96;
         public const int    FakeHideX              = -10000;
         public const int    FakeHideY              = -10000;

--- a/Plugins.sln/Cube3D/Config/Const.cs
+++ b/Plugins.sln/Cube3D/Config/Const.cs
@@ -15,7 +15,7 @@ namespace Cube3D.Config
         public const double FakeHideX                 = -10000.0;
         public const double FakeHideY                 = -10000.0;
         public const int    CaptureInitTimer          = 50;
-        public const int    AnimationDurationMin      = 500;
+        public const int    AnimationDurationMin      = 100;
         public const int    AnimationDurationMax      = 1000;
         public const int    CheckAliveIntervalMin     = 1;
         public const int    CheckAliveIntervalMax     = 60;

--- a/Plugins.sln/Cube3D/SettingsWindow.xaml
+++ b/Plugins.sln/Cube3D/SettingsWindow.xaml
@@ -14,7 +14,7 @@
                             <Label Margin="10,10,0,0" Width="180">Animation Duration(ms):</Label>
                             <Slider x:Name="SliderAnimationDuration" Margin="10,15,0,0" HorizontalAlignment="Left" Width="300"
                                     IsSnapToTickEnabled="True" IsMoveToPointEnabled="True"
-                                    Minimum="500" Maximum="1000" Value="{Binding AnimationDuration}" TickFrequency="10" TickPlacement="None" LargeChange="10" />
+                                    Minimum="100" Maximum="1000" Value="{Binding AnimationDuration}" TickFrequency="10" TickPlacement="None" LargeChange="10" />
                             <TextBlock Margin="5,16,0,0" Text="{Binding ElementName=SliderAnimationDuration, Path=Value}" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal">

--- a/VirtualSpace/MainWindow.hotkeys.cs
+++ b/VirtualSpace/MainWindow.hotkeys.cs
@@ -27,6 +27,7 @@ namespace VirtualSpace
     public partial class MainWindow
     {
         private static          bool   _inRising;
+        private static          bool   _switching;
         private static readonly IntPtr Handled = (IntPtr)1;
 
         private void RegisterHotKey( IntPtr hWnd )
@@ -107,7 +108,27 @@ namespace VirtualSpace
                         case Keys.Right:
                         case Keys.Up:
                         case Keys.Down:
-                            User32.PostMessage( Handle, WinMsg.WM_HOTKEY, UserMessage.SwitchDesktop, (uint)info.vkCode );
+                            if (!_switching)
+                            {
+                                _switching = true;
+                                User32.PostMessage(Handle, WinMsg.WM_HOTKEY, UserMessage.SwitchDesktop, (uint)info.vkCode);
+                            }
+                            return Handled;
+                    }
+                }
+
+                if (keyType == LLGHK.WM_KEYUP
+                     && User32.GetAsyncKeyState((int)Keys.LWin) < 0
+                     && User32.GetAsyncKeyState((int)Keys.LControlKey) < 0) // hook LWin+LCtrl+<DirKey> for switch virtual desktop
+                {
+                    var key = (Keys)info.vkCode;
+                    switch (key)
+                    {
+                        case Keys.Left:
+                        case Keys.Right:
+                        case Keys.Up:
+                        case Keys.Down:
+                            _switching = false;
                             return Handled;
                     }
                 }


### PR DESCRIPTION
- allow shorter user-configurable animations (minimum changed from 500ms to 100ms)
- force only one desktop switch per key press (keeping a key pressed will no longer automatically keep switching to the next desktop)